### PR TITLE
Add docker-compose for local test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,12 @@ function to let it type the queries. In order to do that `squirrel` will have to
 connect to a postgres server that must be running during the tests.
 
 - In CI this is taken care of automatically
-- Locally you'll need a little bit of setup:
+
+- Locally you can run the tests using Docker Compose to start a postgres db or using a manual setup.
+- To use Docker compose:
+  - In one terminal run `docker compose up`
+  - In another terminal run the tests
+- Without Docker Compose, you will need a PG instance running with:
   - There must be a user called `squirrel_test`
   - It must be able to read and write to a database called `squirrel_test`
   - It will use the empty password to connect at `localhost`'s port `5432`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  postgres:
+    container_name: squirrel-test
+    image: postgres:16
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: squirrel_test
+      POSTGRES_DB: squirrel_test
+    ports:
+      - 5432:5432
+    hostname: postgres
+    expose:
+      - 5432


### PR DESCRIPTION
Contributing is a bit cumbersome because you need a PG server running.
This could be easier if you do this using docker compose locally.
This adds a `docker-compose.yml` and instructions. 
For your consideration, thanks