### PR TITLE
`postgresql` Scheme Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- Added support for `postgresql` URL scheme.
+  ([Valentin Iancu])(https://github.com/valentindiancu)
+
 ## v1.7.0 - 2024-09-09
 
 - Fixed a bug where an authentication error would result in a failure with a


### PR DESCRIPTION
Squirrel currently does not support the `postgresql` scheme for DATABASE_URL which is a valid alternative for a postgres connection string.  Considering the package already has the gleam_pgo dependency, I've simply re-used its URL parser which is also covered by tests.