### PR TITLE
bump minimum gleam_stdlib version to 0.39.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ repository = { type = "github", user = "giacomocavalieri", repo = "squirrel" }
 gleam = ">= 1.4.0"
 
 [dependencies]
-gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+gleam_stdlib = ">= 0.39.0 and < 2.0.0"
 simplifile = ">= 2.0.1 and < 3.0.0"
 eval = ">= 1.0.0 and < 2.0.0"
 gleam_json = ">= 1.0.0 and < 3.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -50,7 +50,7 @@ gleam_community_ansi = { version = ">= 1.4.0 and < 2.0.0" }
 gleam_crypto = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_json = { version = ">= 1.0.0 and < 3.0.0" }
 gleam_pgo = { version = ">= 0.13.0 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.39.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 justin = { version = ">= 1.0.1 and < 2.0.0" }
 mug = { version = ">= 1.1.0 and < 2.0.0" }


### PR DESCRIPTION
Just a small PR to update the minimum version of `gleam_stdlib` to 0.39.0.

Fixes https://github.com/giacomocavalieri/squirrel/issues/26
