### PR TITLE
Fix deprecation warnings for stdlib

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -25,6 +25,7 @@ youid = ">= 1.2.0 and < 2.0.0"
 non_empty_list = ">= 2.1.0 and < 3.0.0"
 tote = ">= 1.0.2 and < 2.0.0"
 pog = ">= 1.0.1 and < 2.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -18,7 +18,8 @@ packages = [
   { name = "gleam_crypto", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "8AE56026B3E05EBB1F076778478A762E9EB62B31AEEB4285755452F397029D22" },
   { name = "gleam_erlang", version = "0.30.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "760618870AE4A497B10C73548E6E44F43B76292A54F0207B3771CBB599C675B4" },
   { name = "gleam_json", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB10B0E7BF44282FB25162F1A24C1A025F6B93E777CCF238C4017E4EEF2CDE97" },
-  { name = "gleam_stdlib", version = "0.43.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "69EF22E78FDCA9097CBE7DF91C05B2A8B5436826D9F66680D879182C0860A747" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.45.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "206FCE1A76974AECFC55AEBCD0217D59EDE4E408C016E2CFCCC8FF51278F186E" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "glexer", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "BD477AD657C2B637FEF75F2405FAEFFA533F277A74EF1A5E17B55B1178C228FB" },
   { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
@@ -51,6 +52,7 @@ gleam_community_ansi = { version = ">= 1.4.0 and < 2.0.0" }
 gleam_crypto = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 0.27.0 and < 1.0.0" }
 gleam_json = { version = ">= 1.0.0 and < 3.0.0" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.39.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 justin = { version = ">= 1.0.1 and < 2.0.0" }

--- a/src/squirrel/internal/error.gleam
+++ b/src/squirrel/internal/error.gleam
@@ -1,9 +1,9 @@
+import gleam/regexp
 import glam/doc.{type Document}
 import gleam/int
 import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/regex
 import gleam/result
 import gleam/string
 import gleam_community/ansi
@@ -852,19 +852,19 @@ fn syntax_highlight(content: String) -> String {
 
   let assert Ok(keyword) =
     { "\\b(" <> keywords <> ")\\b" <> not_inside_string }
-    |> regex.compile(regex.Options(True, False))
+    |> regexp.compile(regexp.Options(True, False))
   let assert Ok(number) =
-    regex.from_string("(?<!\\$)\\b(\\d+(\\.\\d+)?\\b)" <> not_inside_string)
-  let assert Ok(comment) = regex.from_string("(^\\s*--.*)")
-  let assert Ok(string) = regex.from_string("(\\'.*\\')")
-  let assert Ok(hole) = regex.from_string("(\\$\\d+)" <> not_inside_string)
+    regexp.from_string("(?<!\\$)\\b(\\d+(\\.\\d+)?\\b)" <> not_inside_string)
+  let assert Ok(comment) = regexp.from_string("(^\\s*--.*)")
+  let assert Ok(string) = regexp.from_string("(\\'.*\\')")
+  let assert Ok(hole) = regexp.from_string("(\\$\\d+)" <> not_inside_string)
 
   content
-  |> regex.replace(each: comment, with: "\u{001B}[2m\\1\u{001B}[0m")
-  |> regex.replace(each: keyword, with: "\u{001B}[36m\\1\u{001B}[39m")
-  |> regex.replace(each: string, with: "\u{001B}[33m\\1\u{001B}[39m")
-  |> regex.replace(each: number, with: "\u{001B}[32m\\1\u{001B}[39m")
-  |> regex.replace(each: hole, with: "\u{001B}[35m\\1\u{001B}[39m")
+  |> regexp.replace(each: comment, with: "\u{001B}[2m\\1\u{001B}[0m")
+  |> regexp.replace(each: keyword, with: "\u{001B}[36m\\1\u{001B}[39m")
+  |> regexp.replace(each: string, with: "\u{001B}[33m\\1\u{001B}[39m")
+  |> regexp.replace(each: number, with: "\u{001B}[32m\\1\u{001B}[39m")
+  |> regexp.replace(each: hole, with: "\u{001B}[35m\\1\u{001B}[39m")
 }
 
 fn report_bug_doc(additional_info: String) -> Document {

--- a/src/squirrel/internal/error.gleam
+++ b/src/squirrel/internal/error.gleam
@@ -1,9 +1,9 @@
-import gleam/regexp
 import glam/doc.{type Document}
 import gleam/int
 import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/regexp
 import gleam/result
 import gleam/string
 import gleam_community/ansi

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -1,3 +1,4 @@
+import gleam/regexp
 import argv
 import envoy
 import filepath
@@ -6,7 +7,6 @@ import gleam/erlang
 import gleam/erlang/atom
 import gleam/io
 import gleam/list
-import gleam/regex
 import gleam/string
 import shellout
 import simplifile
@@ -319,6 +319,6 @@ fn test_project(dir: String) -> Result(String, #(Int, String)) {
 }
 
 fn safe_name(string: String) {
-  let assert Ok(regex) = regex.from_string("[()\\[\\]]")
-  regex.replace(each: regex, with: "_", in: string)
+  let assert Ok(regex) = regexp.from_string("[()\\[\\]]")
+  regexp.replace(each: regex, with: "_", in: string)
 }

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -1,4 +1,3 @@
-import gleam/regexp
 import argv
 import envoy
 import filepath
@@ -7,6 +6,7 @@ import gleam/erlang
 import gleam/erlang/atom
 import gleam/io
 import gleam/list
+import gleam/regexp
 import gleam/string
 import shellout
 import simplifile


### PR DESCRIPTION
This PR updates the standard library dependency and fixes the deprecation warnings, adding the `gleam_regexp` package instead of using `gleam/regex`