### PR TITLE
Remove import of gleam/list

### DIFF
--- a/birdie_snapshots/array_encoding.accepted
+++ b/birdie_snapshots/array_encoding.accepted
@@ -5,7 +5,6 @@ file: ./test/squirrel_test.gleam
 test_name: array_encoding_test
 ---
 import gleam/dynamic/decode
-import gleam/list
 import pog
 
 /// A row you get from running the `query` query

--- a/src/squirrel/internal/query.gleam
+++ b/src/squirrel/internal/query.gleam
@@ -250,7 +250,6 @@ fn gleam_type_to_encoder(
   let name = doc.from_string(name)
   case type_ {
     gleam.List(type_) -> {
-      let state = state |> import_module("gleam/list")
       let #(state, inner_encoder) = gleam_type_to_encoder(state, type_, "value")
       let map_fn = fn_doc(["value"], inner_encoder)
       let doc = call_doc("pog.array", [map_fn, name])


### PR DESCRIPTION
In my project, squirrel generates a line with `import gleam/list`, but the module is not actually used. This leads to a warning which is a bit annoying :3

It seems like the import is a leftover from when previous versions of `pog`/`pgo` required a `list.map` call for the `array` function. I couldn't find any other places where it would be used.