### PR TITLE
chore: fix result.then deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Updated `result.then` to `result.try` to resolve deprecation warnings.
+
 ## v3.0.6 - 2025-06-24
 
 - Updated the `mug` dependency to `>= 2.0.0 and < 3.0.0`

--- a/src/squirrel.gleam
+++ b/src/squirrel.gleam
@@ -195,7 +195,7 @@ fn connection_options_from_variables() -> postgres.ConnectionOptions {
     |> result.unwrap(default_database)
   let port =
     envoy.get("PGPORT")
-    |> result.then(int.parse)
+    |> result.try(int.parse)
     |> result.unwrap(default_port)
 
   postgres.ConnectionOptions(

--- a/src/squirrel/internal/database/postgres.gleam
+++ b/src/squirrel/internal/database/postgres.gleam
@@ -396,7 +396,7 @@ fn ensure_postgres_version() -> Db(Nil) {
   let assert [[version, ..], ..] = version
     as "select version should always return at least one row"
 
-  case bit_array.to_string(version) |> result.then(int.parse) {
+  case bit_array.to_string(version) |> result.try(int.parse) {
     Error(_) -> eval.throw(error.PostgresVersionHasInvalidFormat(version))
     Ok(version) if version >= minimum_required_version -> eval.return(Nil)
     Ok(_) -> eval.throw(error.PostgresVersionIsTooOld)

--- a/src/squirrel/internal/error.gleam
+++ b/src/squirrel/internal/error.gleam
@@ -752,7 +752,7 @@ fn code_doc(
 ) {
   let pointer =
     option.to_result(pointer, Nil)
-    |> result.then(pointer_doc(_, content))
+    |> result.try(pointer_doc(_, content))
 
   let content = syntax_highlight(content)
   let lines = string.split(content, on: "\n")


### PR DESCRIPTION
To resolve the recent deprecation of `result.then`, I've updated to `result.try`.