### PR TITLE
Add support for naming generated function parameters via comments

### DIFF
--- a/birdie_snapshots/multiple_named_params.accepted
+++ b/birdie_snapshots/multiple_named_params.accepted
@@ -1,0 +1,53 @@
+---
+version: 1.5.1
+title: multiple named params
+file: ./test/squirrel_test.gleam
+test_name: multiple_named_params_test
+---
+//// This module contains the code to run the sql queries defined in
+//// `./test-directory`.
+//// > 🐿️ This module was generated automatically using v-test of
+//// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+////
+
+import gleam/dynamic/decode
+import pog
+
+/// A row you get from running the `query` query
+/// defined in `query.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v-test of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type QueryRow {
+  QueryRow(res: Bool)
+}
+
+/// Runs the `query` query
+/// defined in `query.sql`.
+///
+/// > 🐿️ This function was generated automatically using v-test of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn query(
+  db: pog.Connection,
+  user_id: Int,
+  status: String,
+) -> Result(pog.Returned(QueryRow), pog.QueryError) {
+  let decoder = {
+    use res <- decode.field(0, decode.bool)
+    decode.success(QueryRow(res:))
+  }
+
+  "
+-- $1 = user_id
+-- $2 = status
+select true as res where $1 = 11 and $2 = 'active'
+"
+  |> pog.query
+  |> pog.parameter(pog.int(user_id))
+  |> pog.parameter(pog.text(status))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+

--- a/birdie_snapshots/named_param_fallback_to_arg_when_no_name.accepted
+++ b/birdie_snapshots/named_param_fallback_to_arg_when_no_name.accepted
@@ -1,0 +1,30 @@
+---
+version: 1.5.1
+title: named param fallback to arg when no name
+file: ./test/squirrel_test.gleam
+test_name: named_param_fallback_to_arg_when_no_name_test
+---
+
+import gleam/dynamic/decode
+import pog
+
+pub type QueryRow {
+  QueryRow(res: Bool)
+}
+
+pub fn query(
+  db: pog.Connection,
+  arg_1: Int,
+) -> Result(pog.Returned(QueryRow), pog.QueryError) {
+  let decoder = {
+    use res <- decode.field(0, decode.bool)
+    decode.success(QueryRow(res:))
+  }
+
+  "select true as res where $1 = 11"
+  |> pog.query
+  |> pog.parameter(pog.int(arg_1))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+

--- a/birdie_snapshots/named_param_generates_named_argument.accepted
+++ b/birdie_snapshots/named_param_generates_named_argument.accepted
@@ -1,0 +1,50 @@
+---
+version: 1.5.1
+title: named param generates named argument
+file: ./test/squirrel_test.gleam
+test_name: named_param_generates_named_argument_test
+---
+//// This module contains the code to run the sql queries defined in
+//// `./test-directory`.
+//// > 🐿️ This module was generated automatically using v-test of
+//// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+////
+
+import gleam/dynamic/decode
+import pog
+
+/// A row you get from running the `query` query
+/// defined in `query.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v-test of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type QueryRow {
+  QueryRow(res: Bool)
+}
+
+/// Runs the `query` query
+/// defined in `query.sql`.
+///
+/// > 🐿️ This function was generated automatically using v-test of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn query(
+  db: pog.Connection,
+  my_name: Int,
+) -> Result(pog.Returned(QueryRow), pog.QueryError) {
+  let decoder = {
+    use res <- decode.field(0, decode.bool)
+    decode.success(QueryRow(res:))
+  }
+
+  "
+-- $1 = my_name
+select true as res where $1 = 11
+"
+  |> pog.query
+  |> pog.parameter(pog.int(my_name))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+

--- a/src/squirrel/internal/database/postgres.gleam
+++ b/src/squirrel/internal/database/postgres.gleam
@@ -46,6 +46,7 @@ fn find_postgres_type_query() -> UntypedQuery {
     starting_line: 1,
     name:,
     comment: [],
+    param_names: dict.new(),
     content: "
 with recursive types as (
     -- This selects the initial type, it might be an array!
@@ -97,6 +98,7 @@ fn find_enum_variants_query() -> UntypedQuery {
     starting_line: 1,
     name:,
     comment: [],
+    param_names: dict.new(),
     content: "
 select enumlabel
 from pg_enum
@@ -114,6 +116,7 @@ fn find_column_nullability_query() -> UntypedQuery {
     starting_line: 1,
     name:,
     comment: [],
+    param_names: dict.new(),
     content: "
 select
   -- Whether the column has a not-null constraint.
@@ -136,6 +139,7 @@ fn find_postgres_version_query() -> UntypedQuery {
     starting_line: 1,
     name:,
     comment: [],
+    param_names: dict.new(),
     content: "select current_setting('server_version_num')",
   )
 }
@@ -1273,7 +1277,9 @@ fn with_cached_column(
 // --- HELPERS TO BUILD ERRORS -------------------------------------------------
 
 fn unsupported_type_error(query: UntypedQuery, type_: String) -> Error {
-  let UntypedQuery(content:, file:, name:, starting_line:, comment: _) = query
+  let UntypedQuery(
+    content:, file:, name:, starting_line:, comment: _, param_names: _,
+  ) = query
   error.QueryHasUnsupportedType(
     file:,
     name: gleam.value_identifier_to_string(name),
@@ -1284,7 +1290,9 @@ fn unsupported_type_error(query: UntypedQuery, type_: String) -> Error {
 }
 
 fn invalid_enum_error(query: UntypedQuery, enum_name: String, reason: EnumError) {
-  let UntypedQuery(content:, file:, name: _, starting_line:, comment: _) = query
+  let UntypedQuery(
+    content:, file:, name: _, starting_line:, comment: _, param_names: _,
+  ) = query
   error.QueryHasInvalidEnum(
     file:,
     content:,
@@ -1301,7 +1309,9 @@ fn cannot_parse_error(
   additional_error_message additional_error_message: Option(String),
   pointer pointer: Option(Pointer),
 ) -> Error {
-  let UntypedQuery(content:, file:, name:, starting_line:, comment: _) = query
+  let UntypedQuery(
+    content:, file:, name:, starting_line:, comment: _, param_names: _,
+  ) = query
   error.CannotParseQuery(
     content:,
     file:,
@@ -1319,7 +1329,9 @@ fn invalid_column_error(
   column_name: String,
   reason: ValueIdentifierError,
 ) -> Error {
-  let UntypedQuery(name: _, file:, content:, starting_line:, comment: _) = query
+  let UntypedQuery(
+    name: _, file:, content:, starting_line:, comment: _, param_names: _,
+  ) = query
   error.QueryHasInvalidColumn(
     file:,
     column_name:,

--- a/src/squirrel/internal/query.gleam
+++ b/src/squirrel/internal/query.gleam
@@ -5,6 +5,7 @@ import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
 import gleam/option.{None, Some}
+import gleam/regexp
 import gleam/result
 import gleam/set.{type Set}
 import gleam/string
@@ -36,6 +37,9 @@ pub type UntypedQuery {
     /// The text of the query itself.
     ///
     content: String,
+    /// Named parameter mappings extracted from SQL comments (position -> name).
+    ///
+    param_names: Dict(Int, String),
   )
 }
 
@@ -51,6 +55,7 @@ pub type TypedQuery {
     content: String,
     params: List(gleam.Type),
     returns: List(gleam.Field),
+    param_names: Dict(Int, String),
   )
 }
 
@@ -61,7 +66,14 @@ pub fn add_types(
   params params: List(gleam.Type),
   returns returns: List(gleam.Field),
 ) -> Result(TypedQuery, Error) {
-  let UntypedQuery(file:, name:, comment:, content:, starting_line:) = query
+  let UntypedQuery(
+    file:,
+    name:,
+    comment:,
+    content:,
+    starting_line:,
+    param_names:,
+  ) = query
 
   case duplicate_names(returns) {
     [] ->
@@ -73,6 +85,7 @@ pub fn add_types(
         starting_line:,
         params:,
         returns:,
+        param_names:,
       ))
 
     names ->
@@ -127,12 +140,15 @@ pub fn from_file(file: String) -> Result(UntypedQuery, Error) {
     ))
 
   use name <- result.try(name)
+  let comment = take_comment(content)
+  let #(param_names, comment) = extract_param_names(comment)
   Ok(UntypedQuery(
     file:,
     starting_line: 1,
     name:,
     content:,
-    comment: take_comment(content),
+    comment:,
+    param_names:,
   ))
 }
 
@@ -149,6 +165,39 @@ fn do_take_comment(query: String, lines: List(String)) -> List(String) {
       }
     _ -> list.reverse(lines)
   }
+}
+
+/// Extracts named parameter mappings from SQL comments.
+/// Comments like `-- $1 = name` are parsed and removed from the comment list.
+/// The remaining comments are returned as the documentation.
+///
+@internal
+pub fn extract_param_names(
+  comments: List(String),
+) -> #(Dict(Int, String), List(String)) {
+  // $1 = name
+  let assert Ok(pattern) =
+    regexp.from_string("^\\$(\\d+)\\s*=\\s*([a-zA-Z_][a-zA-Z0-9_]*)$")
+
+  let #(name_comments, other_comments) =
+    list.partition(comments, regexp.check(pattern, _))
+
+  let param_names =
+    list.fold(over: name_comments, from: dict.new(), with: fn(acc, comment) {
+      let assert [match] = regexp.scan(pattern, comment)
+
+      case match.submatches {
+        [Some(position), Some(name)] -> {
+          case int.parse(position) {
+            Ok(position) -> dict.insert(acc, position, name)
+            _ -> acc
+          }
+        }
+        _ -> acc
+      }
+    })
+
+  #(param_names, other_comments)
 }
 
 // --- CODE GENERATION ---------------------------------------------------------
@@ -498,6 +547,7 @@ fn query_doc(
     params:,
     returns:,
     starting_line: _,
+    param_names:,
   ) = query
 
   let constructor_name =
@@ -515,12 +565,15 @@ fn query_doc(
     let acc = #(state, [], [])
     use #(state, args, encoders), param, i <- list.index_fold(params, acc)
 
-    let arg = "arg_" <> int.to_string(i + 1)
+    let arg_name = case dict.get(param_names, i + 1) {
+      Ok(name) -> name
+      Error(_) -> "arg_" <> int.to_string(i + 1)
+    }
     let #(state, arg_type) =
       gleam_type_to_field_type(state, param, FunctionArgument)
-    let #(state, encoder) = gleam_type_to_encoder(state, param, arg)
+    let #(state, encoder) = gleam_type_to_encoder(state, param, arg_name)
 
-    let arg = doc.concat([doc.from_string(arg <> ": "), arg_type])
+    let arg = doc.concat([doc.from_string(arg_name <> ": "), arg_type])
     #(state, [arg, ..args], [encoder, ..encoders])
   }
   let args = list.reverse(args)

--- a/test/squirrel_test.gleam
+++ b/test/squirrel_test.gleam
@@ -1,10 +1,12 @@
 import birdie
 import filepath
 import glam/doc
+import gleam/dict
 import gleam/erlang/process
 import gleam/list
 import gleam/string
 import gleeunit
+
 import global_value
 import pog
 import simplifile
@@ -1036,4 +1038,65 @@ pub fn enum_with_a_long_enoug_name_does_not_generate_invalid_decoder_test() {
   |> birdie.snap(
     title: "enum with a long enoug name does not generate invalid decoder",
   )
+}
+
+pub fn extract_param_names_empty_test() {
+  let #(names, comments) = query.extract_param_names([])
+  assert dict.is_empty(names)
+  assert list.is_empty(comments)
+}
+
+pub fn extract_param_names_no_naming_test() {
+  let #(names, comments) =
+    query.extract_param_names(["a comment", "another comment"])
+  assert dict.is_empty(names)
+  assert comments == ["a comment", "another comment"]
+}
+
+pub fn extract_param_names_single_test() {
+  let #(names, comments) =
+    query.extract_param_names(["$1 = user_id", "a comment"])
+  assert dict.get(names, 1) == Ok("user_id")
+  assert comments == ["a comment"]
+}
+
+pub fn extract_param_names_multiple_test() {
+  let #(names, comments) =
+    query.extract_param_names(["$1 = user_id", "$2 = status", "some note"])
+  assert dict.get(names, 1) == Ok("user_id")
+  assert dict.get(names, 2) == Ok("status")
+  assert comments == ["some note"]
+}
+
+pub fn extract_param_names_unnamed_preserved_test() {
+  let #(names, comments) =
+    query.extract_param_names(["$1 = user_id", "regular note", "$3 = status"])
+  assert dict.get(names, 1) == Ok("user_id")
+  assert dict.get(names, 3) == Ok("status")
+  assert !list.is_empty(comments)
+}
+
+pub fn named_param_generates_named_argument_test() {
+  "
+-- $1 = my_name
+select true as res where $1 = 11
+"
+  |> should_codegen_with_comments
+  |> birdie.snap(title: "named param generates named argument")
+}
+
+pub fn named_param_fallback_to_arg_when_no_name_test() {
+  "select true as res where $1 = 11"
+  |> should_codegen
+  |> birdie.snap(title: "named param fallback to arg when no name")
+}
+
+pub fn multiple_named_params_test() {
+  "
+-- $1 = user_id
+-- $2 = status
+select true as res where $1 = 11 and $2 = 'active'
+"
+  |> should_codegen_with_comments
+  |> birdie.snap(title: "multiple named params")
 }


### PR DESCRIPTION
This PR adds support for naming parameters of the generated query.

Such as when generating code from the following SQL:
```sql
-- Update an existing item category
-- $1 = id
-- $2 = name
-- $3 = color

update item_categories set name = $2, color = $3 where id = $1;
```

will generate a function that has named parameters (`id`, `name` and `color`) rather than generic `arg_1`, `arg_2` and `arg_3`.

I've chosen to implement this using comments, so that the sql is still valid (I was also considering using `$name, $color` in the SQL and then translating it to `$1`, $2`, but that would not be valid postgres SQL).