### PR TITLE
Support a nullable type hint comment for parameters

### DIFF
--- a/src/squirrel/internal/database/postgres.gleam
+++ b/src/squirrel/internal/database/postgres.gleam
@@ -554,26 +554,10 @@ fn infer_types(query: UntypedQuery) -> Db(TypedQuery) {
   // - The parameters' types are just OIDs so we need to interrogate the
   //   database to learn the actual corresponding Gleam type.
 
-  let param_nullables = case query.comment {
-    ["$nullable_hint: " <> param_list_str, ..] ->
-      param_list_str
-      |> string.split(",")
-      |> list.map(fn(p) {
-        case p |> string.trim |> int.parse {
-          Ok(n) -> n
-          _ -> 0
-        }
-      })
-      |> list.filter(fn(p) { p >= 0 })
-      |> set.from_list
-    _ -> set.new()
-  }
+  use parameters <- eval.try(resolve_parameters(query, parameters))
 
-  use parameters <- eval.try(resolve_parameters(
-    query,
-    parameters,
-    param_nullables,
-  ))
+  let param_nullables = nullable_from_comments(query)
+  let parameters = wrap_param_nullables(parameters, param_nullables)
 
   // - The returns' types are just OIDs so we have to do the same for those.
   // - Here comes the tricky part: we can't know if a column is nullable just
@@ -600,6 +584,19 @@ fn infer_types(query: UntypedQuery) -> Db(TypedQuery) {
   query
   |> query.add_types(parameters, returns)
   |> eval.from_result
+}
+
+fn nullable_from_comments(query: UntypedQuery) -> Set(Int) {
+  case query.comment {
+    ["$nullable_hint: " <> param_list_str, ..] ->
+      param_list_str
+      |> string.split(",")
+      |> list.map(fn(p) { p |> string.trim |> int.parse })
+      |> result.values
+      |> list.map(fn(p) { p - 1 })
+      |> set.from_list
+    _ -> set.new()
+  }
 }
 
 fn parameters_and_returns(query: UntypedQuery) -> Db(_) {
@@ -726,10 +723,9 @@ fn error_fields_to_parse_error(
 fn resolve_parameters(
   query: UntypedQuery,
   parameters: List(Int),
-  nullables: Set(Int),
 ) -> Db(List(gleam.Type)) {
-  use oid, idx <- eval_extra.try_index_map(parameters)
-  find_gleam_type(query, oid, set.contains(nullables, idx + 1))
+  use oid <- eval_extra.try_map(parameters)
+  find_gleam_type(query, oid)
 }
 
 /// Looks up a type with the given id in the Postgres registry.
@@ -738,14 +734,10 @@ fn resolve_parameters(
 /// > will crash otherwise. This should only be called with oids coming from
 /// > a database interrogation.
 ///
-fn find_gleam_type(
-  query: UntypedQuery,
-  oid: Int,
-  is_nullable: Bool,
-) -> Db(gleam.Type) {
+fn find_gleam_type(query: UntypedQuery, oid: Int) -> Db(gleam.Type) {
   // We first look for the Gleam type corresponding to this id in the cache to
   // avoid hammering the db with needless queries.
-  use <- with_cached_gleam_type(oid, is_nullable)
+  use <- with_cached_gleam_type(oid)
 
   // The only parameter to this query is the oid of the type to lookup:
   // that's a 32bit integer (its oid needed to prepare the query is 23).
@@ -935,7 +927,7 @@ fn resolve_returns(
     ..,
   ) = column
 
-  use type_ <- eval.try(find_gleam_type(query, type_oid, False))
+  use type_ <- eval.try(find_gleam_type(query, type_oid))
 
   let ends_with_exclamation_mark = string.ends_with(name, "!")
   let ends_with_question_mark = string.ends_with(name, "?")
@@ -1257,19 +1249,17 @@ fn unsupported_authentication(auth: String) -> Db(a) {
 ///
 fn with_cached_gleam_type(
   lookup oid: Int,
-  is_nullable is_nullable: Bool,
   otherwise do: fn() -> Db(gleam.Type),
 ) -> Db(gleam.Type) {
   use context: Context <- eval.from
   case dict.get(context.gleam_types, oid) {
-    Ok(type_) -> #(context, Ok(wrap_nullable(type_, is_nullable)))
+    Ok(type_) -> #(context, Ok(type_))
 
     Error(_) ->
       case eval.step(do(), context) {
         #(_, Error(_)) as result -> result
         #(Context(gleam_types:, ..) as context, Ok(type_)) -> {
           let gleam_types = dict.insert(gleam_types, oid, type_)
-          let type_ = wrap_nullable(type_, is_nullable)
           let new_context = Context(..context, gleam_types:)
           #(new_context, Ok(type_))
         }
@@ -1277,11 +1267,17 @@ fn with_cached_gleam_type(
   }
 }
 
-fn wrap_nullable(type_: gleam.Type, is_nullable: Bool) -> gleam.Type {
-  case is_nullable {
-    True -> gleam.Option(type_)
-    False -> type_
-  }
+fn wrap_param_nullables(
+  types: List(gleam.Type),
+  nullables: Set(Int),
+) -> List(gleam.Type) {
+  types
+  |> list.index_map(fn(type_, idx) {
+    case set.contains(nullables, idx) {
+      True -> gleam.Option(type_)
+      False -> type_
+    }
+  })
 }
 
 /// Looks up for the nullability of table's column.

--- a/src/squirrel/internal/database/postgres.gleam
+++ b/src/squirrel/internal/database/postgres.gleam
@@ -553,12 +553,11 @@ fn infer_types(query: UntypedQuery) -> Db(TypedQuery) {
   use #(parameters, returns) <- eval.try(parameters_and_returns(query))
   // - The parameters' types are just OIDs so we need to interrogate the
   //   database to learn the actual corresponding Gleam type.
-
   use parameters <- eval.try(resolve_parameters(query, parameters))
-
-  let param_nullables = nullable_from_comments(query)
+  // - We scan the first line of comments for nullable hints, and wrap
+  //   parameters accordingly.
+  let param_nullables = nullables_from_comments(query)
   let parameters = wrap_param_nullables(parameters, param_nullables)
-
   // - The returns' types are just OIDs so we have to do the same for those.
   // - Here comes the tricky part: we can't know if a column is nullable just
   //   from the server's previous answer.
@@ -578,7 +577,6 @@ fn infer_types(query: UntypedQuery) -> Db(TypedQuery) {
       fn(_context, _error) { eval.return(set.new()) },
     ),
   )
-
   use returns <- eval.try(resolve_returns(query, returns, nullables))
 
   query
@@ -586,7 +584,10 @@ fn infer_types(query: UntypedQuery) -> Db(TypedQuery) {
   |> eval.from_result
 }
 
-fn nullable_from_comments(query: UntypedQuery) -> Set(Int) {
+/// Extracts a set of nullable parameters from the first line of comments.
+/// First line must begin with `$nullable_hint: ` followed by a comma separated
+/// list of parameter numbers that will be handled as nullable.
+fn nullables_from_comments(query: UntypedQuery) -> Set(Int) {
   case query.comment {
     ["$nullable_hint: " <> param_list_str, ..] ->
       param_list_str
@@ -597,6 +598,21 @@ fn nullable_from_comments(query: UntypedQuery) -> Set(Int) {
       |> set.from_list
     _ -> set.new()
   }
+}
+
+/// Taking a set of ints and a list of parameter types, wraps the ones that
+/// are present in the set with gleam.Option.
+fn wrap_param_nullables(
+  types: List(gleam.Type),
+  nullables: Set(Int),
+) -> List(gleam.Type) {
+  types
+  |> list.index_map(fn(type_, idx) {
+    case set.contains(nullables, idx) {
+      True -> gleam.Option(type_)
+      False -> type_
+    }
+  })
 }
 
 fn parameters_and_returns(query: UntypedQuery) -> Db(_) {
@@ -1265,19 +1281,6 @@ fn with_cached_gleam_type(
         }
       }
   }
-}
-
-fn wrap_param_nullables(
-  types: List(gleam.Type),
-  nullables: Set(Int),
-) -> List(gleam.Type) {
-  types
-  |> list.index_map(fn(type_, idx) {
-    case set.contains(nullables, idx) {
-      True -> gleam.Option(type_)
-      False -> type_
-    }
-  })
 }
 
 /// Looks up for the nullability of table's column.

--- a/src/squirrel/internal/database/postgres.gleam
+++ b/src/squirrel/internal/database/postgres.gleam
@@ -1270,7 +1270,6 @@ fn with_cached_gleam_type(
   use context: Context <- eval.from
   case dict.get(context.gleam_types, oid) {
     Ok(type_) -> #(context, Ok(type_))
-
     Error(_) ->
       case eval.step(do(), context) {
         #(_, Error(_)) as result -> result

--- a/src/squirrel/internal/database/postgres.gleam
+++ b/src/squirrel/internal/database/postgres.gleam
@@ -553,7 +553,28 @@ fn infer_types(query: UntypedQuery) -> Db(TypedQuery) {
   use #(parameters, returns) <- eval.try(parameters_and_returns(query))
   // - The parameters' types are just OIDs so we need to interrogate the
   //   database to learn the actual corresponding Gleam type.
-  use parameters <- eval.try(resolve_parameters(query, parameters))
+
+  let param_nullables = case query.comment {
+    ["$nullable_hint: " <> param_list_str, ..] ->
+      param_list_str
+      |> string.split(",")
+      |> list.map(fn(p) {
+        case p |> string.trim |> int.parse {
+          Ok(n) -> n
+          _ -> 0
+        }
+      })
+      |> list.filter(fn(p) { p >= 0 })
+      |> set.from_list
+    _ -> set.new()
+  }
+
+  use parameters <- eval.try(resolve_parameters(
+    query,
+    parameters,
+    param_nullables,
+  ))
+
   // - The returns' types are just OIDs so we have to do the same for those.
   // - Here comes the tricky part: we can't know if a column is nullable just
   //   from the server's previous answer.
@@ -573,6 +594,7 @@ fn infer_types(query: UntypedQuery) -> Db(TypedQuery) {
       fn(_context, _error) { eval.return(set.new()) },
     ),
   )
+
   use returns <- eval.try(resolve_returns(query, returns, nullables))
 
   query
@@ -704,9 +726,10 @@ fn error_fields_to_parse_error(
 fn resolve_parameters(
   query: UntypedQuery,
   parameters: List(Int),
+  nullables: Set(Int),
 ) -> Db(List(gleam.Type)) {
-  use oid <- eval_extra.try_map(parameters)
-  find_gleam_type(query, oid)
+  use oid, idx <- eval_extra.try_index_map(parameters)
+  find_gleam_type(query, oid, set.contains(nullables, idx + 1))
 }
 
 /// Looks up a type with the given id in the Postgres registry.
@@ -715,10 +738,14 @@ fn resolve_parameters(
 /// > will crash otherwise. This should only be called with oids coming from
 /// > a database interrogation.
 ///
-fn find_gleam_type(query: UntypedQuery, oid: Int) -> Db(gleam.Type) {
+fn find_gleam_type(
+  query: UntypedQuery,
+  oid: Int,
+  is_nullable: Bool,
+) -> Db(gleam.Type) {
   // We first look for the Gleam type corresponding to this id in the cache to
   // avoid hammering the db with needless queries.
-  use <- with_cached_gleam_type(oid)
+  use <- with_cached_gleam_type(oid, is_nullable)
 
   // The only parameter to this query is the oid of the type to lookup:
   // that's a 32bit integer (its oid needed to prepare the query is 23).
@@ -908,7 +935,7 @@ fn resolve_returns(
     ..,
   ) = column
 
-  use type_ <- eval.try(find_gleam_type(query, type_oid))
+  use type_ <- eval.try(find_gleam_type(query, type_oid, False))
 
   let ends_with_exclamation_mark = string.ends_with(name, "!")
   let ends_with_question_mark = string.ends_with(name, "?")
@@ -1230,20 +1257,30 @@ fn unsupported_authentication(auth: String) -> Db(a) {
 ///
 fn with_cached_gleam_type(
   lookup oid: Int,
+  is_nullable is_nullable: Bool,
   otherwise do: fn() -> Db(gleam.Type),
 ) -> Db(gleam.Type) {
   use context: Context <- eval.from
   case dict.get(context.gleam_types, oid) {
-    Ok(type_) -> #(context, Ok(type_))
+    Ok(type_) -> #(context, Ok(wrap_nullable(type_, is_nullable)))
+
     Error(_) ->
       case eval.step(do(), context) {
         #(_, Error(_)) as result -> result
         #(Context(gleam_types:, ..) as context, Ok(type_)) -> {
+          let type_ = wrap_nullable(type_, is_nullable)
           let gleam_types = dict.insert(gleam_types, oid, type_)
           let new_context = Context(..context, gleam_types:)
           #(new_context, Ok(type_))
         }
       }
+  }
+}
+
+fn wrap_nullable(type_: gleam.Type, is_nullable: Bool) -> gleam.Type {
+  case is_nullable {
+    True -> gleam.Option(type_)
+    False -> type_
   }
 }
 

--- a/src/squirrel/internal/database/postgres.gleam
+++ b/src/squirrel/internal/database/postgres.gleam
@@ -589,7 +589,7 @@ fn infer_types(query: UntypedQuery) -> Db(TypedQuery) {
 /// list of parameter numbers that will be handled as nullable.
 fn nullables_from_comments(query: UntypedQuery) -> Set(Int) {
   case query.comment {
-    ["$nullable_hint: " <> param_list_str, ..] ->
+    ["@nullable: " <> param_list_str, ..] ->
       param_list_str
       |> string.split(",")
       |> list.map(fn(p) { p |> string.trim |> int.parse })

--- a/src/squirrel/internal/database/postgres.gleam
+++ b/src/squirrel/internal/database/postgres.gleam
@@ -1268,8 +1268,8 @@ fn with_cached_gleam_type(
       case eval.step(do(), context) {
         #(_, Error(_)) as result -> result
         #(Context(gleam_types:, ..) as context, Ok(type_)) -> {
-          let type_ = wrap_nullable(type_, is_nullable)
           let gleam_types = dict.insert(gleam_types, oid, type_)
+          let type_ = wrap_nullable(type_, is_nullable)
           let new_context = Context(..context, gleam_types:)
           #(new_context, Ok(type_))
         }

--- a/test/birdie_snapshots/nullable_hint.accepted
+++ b/test/birdie_snapshots/nullable_hint.accepted
@@ -1,0 +1,35 @@
+---
+version: 2.0.2
+title: nullable hint
+file: ./test/squirrel_test.gleam
+test_name: nullable_hint_test
+---
+
+import gleam/dynamic/decode
+import gleam/option.{type Option}
+import pog
+
+pub fn query(
+  connection: pog.Connection,
+  arg_1: String,
+  arg_2: Option(String),
+  arg_3: String,
+  arg_4: Option(Int),
+  arg_5: Int,
+) -> Result(pog.Returned(Nil), pog.QueryError) {
+  let decoder = decode.map(decode.dynamic, fn(_) { Nil })
+
+  "
+-- $nullable_hint: 2, 4
+  insert into nullable_hint values ($1, $2, $3, $4, $5)
+  "
+  |> pog.query
+  |> pog.parameter(pog.text(arg_1))
+  |> pog.parameter(pog.nullable(fn(value) { pog.text(value) }, arg_2))
+  |> pog.parameter(pog.text(arg_3))
+  |> pog.parameter(pog.nullable(fn(value) { pog.int(value) }, arg_4))
+  |> pog.parameter(pog.int(arg_5))
+  |> pog.returning(decoder)
+  |> pog.execute(connection)
+}
+

--- a/test/birdie_snapshots/nullable_hint.accepted
+++ b/test/birdie_snapshots/nullable_hint.accepted
@@ -20,7 +20,7 @@ pub fn query(
   let decoder = decode.map(decode.dynamic, fn(_) { Nil })
 
   "
--- $nullable_hint: 2, 4
+-- @nullable: 2, 4
   insert into nullable_hint values ($1, $2, $3, $4, $5)
   "
   |> pog.query

--- a/test/birdie_snapshots/nullable_hint.accepted
+++ b/test/birdie_snapshots/nullable_hint.accepted
@@ -21,7 +21,7 @@ pub fn query(
 
   "
 -- @nullable: 2, 4
-  insert into nullable_hint values ($1, $2, $3, $4, $5)
+insert into nullable_hint values ($1, $2, $3, $4, $5)
   "
   |> pog.query
   |> pog.parameter(pog.text(arg_1))

--- a/test/squirrel_test.gleam
+++ b/test/squirrel_test.gleam
@@ -479,7 +479,7 @@ pub fn array_encoding_test() {
 
 pub fn nullable_hint_test() {
   "
--- $nullable_hint: 2, 4
+-- @nullable: 2, 4
   insert into nullable_hint values ($1, $2, $3, $4, $5)
   "
   |> should_codegen

--- a/test/squirrel_test.gleam
+++ b/test/squirrel_test.gleam
@@ -54,6 +54,18 @@ create table if not exists squirrel(
 
   let assert Ok(_) =
     "
+create table if not exists nullable_hint(
+  name text primary key,
+  text2 text,
+  text3 text not null,
+  int1 int,
+  int2 int not null
+    )"
+    |> pog.query
+    |> pog.execute(db)
+
+  let assert Ok(_) =
+    "
 create table if not exists jsons(
   id bigserial primary key,
   json json,
@@ -463,6 +475,15 @@ pub fn array_encoding_test() {
   "select true as res where $1 = array[1, 2, 3]"
   |> should_codegen
   |> birdie.snap(title: "array encoding")
+}
+
+pub fn nullable_hint_test() {
+  "
+-- $nullable_hint: 2, 4
+  insert into nullable_hint values ($1, $2, $3, $4, $5)
+  "
+  |> should_codegen
+  |> birdie.snap(title: "nullable hint")
 }
 
 pub fn optional_decoding_test() {

--- a/test/squirrel_test.gleam
+++ b/test/squirrel_test.gleam
@@ -480,7 +480,7 @@ pub fn array_encoding_test() {
 pub fn nullable_hint_test() {
   "
 -- @nullable: 2, 4
-  insert into nullable_hint values ($1, $2, $3, $4, $5)
+insert into nullable_hint values ($1, $2, $3, $4, $5)
   "
   |> should_codegen
   |> birdie.snap(title: "nullable hint")


### PR DESCRIPTION
Hi! This is an attempt at addressing #82 in line with the suggestions from https://github.com/giacomocavalieri/squirrel/discussions/82#discussioncomment-15244557 and https://github.com/giacomocavalieri/squirrel/issues/51#issuecomment-2552411061

If "magic" comments like this might not be an ideal solution to this and you think is not appropriate for this then that's totally understandable! I thought I'd take a crack at it anyway :D

I opted for this following syntax:

```sql
-- @nullable: 2, 4
insert into nullable_hint values ($1, $2, $3, $4, $5)
```

Which produces:

```gleam
pub fn query(
  connection: pog.Connection,
  arg_1: String,
  arg_2: Option(String),
  arg_3: String,
  arg_4: Option(Int),
  arg_5: Int,
) -> Result(pog.Returned(Nil), pog.QueryError) {
  let decoder = decode.map(decode.dynamic, fn(_) { Nil })

  "
-- @nullable: 2, 4
insert into nullable_hint values ($1, $2, $3, $4, $5)
  "
  |> pog.query
  |> pog.parameter(pog.text(arg_1))
  |> pog.parameter(pog.nullable(fn(value) { pog.text(value) }, arg_2))
  |> pog.parameter(pog.text(arg_3))
  |> pog.parameter(pog.nullable(fn(value) { pog.int(value) }, arg_4))
  |> pog.parameter(pog.int(arg_5))
  |> pog.returning(decoder)
  |> pog.execute(connection)
}
```

Notes:
- I went with the numerical arguments as field names might not be present in the query and I didn't want to get into parsing the query itself to pull field names.
- It only works on the first comment line, and requires a space between `@nullable:` though whitespace is ignored between the argument indices.
- Also added a unit test.
- Open to alternative syntax, or adding flexibility, especially given this may set a precedent for other magic comments in the future.
- One optimisation would be to not have it emit the anonymous function inside `pog.nullable`. e.g.,

```gleam
pog.parameter(pog.nullable(pog.text, arg_2))
```

Few outstanding things to note:

- I know there are some cases where nullable is able to be detected. I didn't check whether supplying a nullable hint in addition to that would cause a double wrapping here. But given I didn't account for any explicit checking of this, assume that is what would happen.
  - [ ] But I want to test if this happens and address if needed. I think a reasonable intended behaviour is we have it _not_ double up on this, and add a unit test to. I'll get to that as soon as I can. Apologies if this is a review blocker!
- Not sure if the way I'm deriving the index (by assuming the parameter list is ordered) is the right way of doing things here, and therefore whether or not the numerical arguments will always match.
   - [x] Do some more testing.
     - After using this with a variety of queries with many parameters and each with a mixture of nullables sprinkled about, it has so far worked as expected.